### PR TITLE
Accept null or undefined on csx function

### DIFF
--- a/src/csx.ts
+++ b/src/csx.ts
@@ -4,11 +4,17 @@ const concat = (a: string, b: string): string => (!!a && !!b ? a + SPACE + b : a
 
 const reducer = (classNames: string, className: cls): string => {
   switch (typeof className) {
+    case 'undefined': 
+      return classNames
     case 'string':
       return concat(classNames, className)
     case 'number':
       return concat(classNames, `${className}`)
     default: {
+      //because typeof null will be 'object'
+      if(className == null) {
+        return classNames
+      }
       const isTruthy = (property: string) =>
         className.hasOwnProperty(property) && className[property]
       return concat(
@@ -23,6 +29,6 @@ const reducer = (classNames: string, className: cls): string => {
 
 const csx = (...classNames: Array<cls>): string => classNames.reduce(reducer, '')
 
-type cls = string | number | { [key: string]: boolean }
+type cls = string | number | { [key: string]: boolean } | undefined | null;
 
 export default csx

--- a/test/csx.test.ts
+++ b/test/csx.test.ts
@@ -1,6 +1,18 @@
 import csx from '../src/csx'
 
 describe('Clssx', () => {
+  it('works with undefined', () => {
+    expect(csx(undefined)).toBe('')
+    expect(csx('flex', 'bold', undefined)).toBe('flex bold')
+    expect(csx('flex', undefined, 'bold')).toBe('flex bold')
+  });
+
+  it('works with null', () => {
+    expect(csx(null)).toBe('')
+    expect(csx('flex', 'bold', null)).toBe('flex bold')
+    expect(csx('flex', null, 'bold')).toBe('flex bold')
+  });
+
   it('Works with strings', () => {
     expect(csx('')).toBe('')
     expect(csx('flex', 'bold', 't-small')).toBe('flex bold t-small')
@@ -33,9 +45,9 @@ describe('Clssx', () => {
   })
 
   it('Works with mixed types', () => {
-    expect(csx('flex', 23, { 'w-100 text-center': true })).toBe('flex 23 w-100 text-center')
+    expect(csx('flex', 23, { 'w-100 text-center': true }, undefined, null)).toBe('flex 23 w-100 text-center')
     expect(
-      csx('flex', 23, { 'w-100 text-center': true }, { 't-small': true, pa4: true }, { xs: false })
+      csx('flex', undefined, 23, { 'w-100 text-center': true }, { 't-small': true, pa4: true }, { xs: false }, null),
     ).toBe('flex 23 w-100 text-center t-small pa4')
   })
 })


### PR DESCRIPTION
- [x] Changed type of `cls` to accept `null` and `undefined` #3 

- [x] Changed handling of `csx` function to take care of `null` and `undefined` 

- [x] added test cases for the same #1 
 